### PR TITLE
docs: clarify source snippet discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ codegraph query <symbol-pattern> [options]
 | `--max-nodes <n>` | Maximum nodes in result | `50` |
 | `--include-external` | Include external assembly dependencies | `false` |
 | `--include-source` | Embed source code snippets alongside node references in output | `false` |
+| `--source-max-lines <n>` | Maximum lines per embedded source snippet | `20` |
 | `--no-rank` | Disable relevance ranking | (ranking enabled by default) |
 | `--budget <tokens>` | Maximum token budget; output is truncated with a hint when exceeded | (none) |
 | `--no-metrics` | Suppress the compression metrics footer | `false` |
@@ -194,6 +195,10 @@ codegraph query <symbol-pattern> [options]
 **Query suggestions:**
 
 After each query, the CLI prints `💡 Suggested next queries:` to stderr with up to three contextual follow-up commands — deeper traversal, call-chain exploration, DI wiring, or cross-assembly scoping. AI agents can follow these hints automatically to navigate the graph efficiently without additional prompting.
+
+**Source retrieval:**
+
+Use `--include-source` after you've narrowed to a specific method or type and want a small inline implementation snippet. Keep `--source-max-lines` low (default: `20`) to stay token-safe. Use the MCP `codegraph_file` tool instead when you only know the file path, need to discover which symbols live in that file, or want to pivot from a changed file to a symbol-level query.
 
 **Edge kind aliases:**
 
@@ -726,10 +731,10 @@ The server exposes 13 tools. Agents call them like any other tool (no shell comm
 
 | MCP Tool | Description |
 |----------|-------------|
-| `codegraph_query` | Query the graph by symbol pattern with depth, edge-type, and format options |
+| `codegraph_query` | Query the graph by symbol pattern with depth, edge-type, and format options; add `include_source` for a capped inline snippet |
 | `codegraph_search` | Search for symbols by name, namespace, or file path |
 | `codegraph_list` | Browse the graph hierarchy (assemblies, types, interfaces, namespaces) |
-| `codegraph_file` | Find all symbols defined in a file path |
+| `codegraph_file` | Find all symbols defined in a file path when you know the file but not the exact symbol |
 | `codegraph_batch` | Query multiple symbols in one call |
 | `codegraph_summary` | Generate an overview report: hub types, assembly boundaries, test coverage |
 | `codegraph_path` | Find the shortest dependency path between two symbols |

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -141,6 +141,8 @@ Query the graph by symbol pattern.
 | `format` | `string` | | `"context"` | Output format: `"context"` (Markdown), `"compact"` (prefix-stripped, 3–5× smaller), `"json"`, or `"text"`. |
 | `max_nodes` | `integer` | | `50` | Maximum nodes to return. |
 | `include_external` | `boolean` | | `false` | Include external (NuGet) dependency nodes. |
+| `include_source` | `boolean` | | `false` | Inline a source snippet for each matched symbol after you've narrowed the query. |
+| `source_max_lines` | `integer` | | `20` | Maximum lines per embedded source snippet. Lower this to stay token-safe. |
 | `confidence` | `string` | | all | Minimum edge confidence: `verified`, `inferred`, or `unresolved` (default: all). |
 | `budget` | `integer` | | (none) | Maximum token budget. Output is truncated with a hint when exceeded. |
 | `solution` | `string` | | all solutions | Scope query to a specific solution name (multi-solution support). |
@@ -205,7 +207,7 @@ Get a comprehensive view of a single symbol: its type, file location, signature,
 
 #### `codegraph_file`
 
-Find all symbols defined in a source file by file path. Use when you know the file but not the individual symbol names — for example, after receiving a list of changed files from `git diff`.
+Find all symbols defined in a source file by file path. Use when you know the file but not the individual symbol names — for example, after receiving a list of changed files from `git diff`. Once you have the symbol, switch to `codegraph_query` with `include_source` for a capped inline snippet.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,14 +47,14 @@ The server exposes thirteen tools. Agents call them like any other tool:
 | MCP Tool | Description |
 |----------|-------------|
 | `codegraph_summary` | Architectural overview: hub types, assembly boundaries, suggested queries |
-| `codegraph_query` | Query the graph by symbol pattern with depth, edge-type, and format options |
+| `codegraph_query` | Query the graph by symbol pattern with depth, edge-type, and format options; add `include_source` and `source_max_lines` for capped inline snippets |
 | `codegraph_search` | Search for symbols by name, namespace, or file path. Best for discovery when you don't know exact names |
 | `codegraph_list` | Browse the graph hierarchy — assemblies, types, interfaces, namespaces |
 | `codegraph_search` | Search symbols by name, namespace, or file path |
 | `codegraph_path` | Find the shortest dependency path between two symbols |
 | `codegraph_impact` | Reverse-dependency analysis — assess the blast radius of a change |
 | `codegraph_explain` | Full symbol deep-dive: signature, members, all edges, test coverage |
-| `codegraph_file` | Find all symbols defined in a file path |
+| `codegraph_file` | Find all symbols defined in a file path when you know the file but not the exact symbol |
 | `codegraph_batch` | Query multiple symbols in one call |
 | `codegraph_compare` | Compare two symbols structurally |
 | `codegraph_test_impact` | Analyze test coverage for a symbol |

--- a/skills/codegraph-query/SKILL.md
+++ b/skills/codegraph-query/SKILL.md
@@ -111,6 +111,8 @@ codegraph query <symbol-pattern> [options]
 | `--format <fmt>` | Output: `context`, `json`, `text` | `context` |
 | `--max-nodes <n>` | Maximum nodes in result | `50` |
 | `--include-external` | Include NuGet/external dependencies | `false` |
+| `--include-source` | Embed a capped source snippet for the matched symbol | `false` |
+| `--source-max-lines <n>` | Maximum lines per embedded source snippet | `20` |
 | `--graph-dir <dir>` | Graph directory | `.codegraph` |
 
 **Edge kind aliases:**
@@ -152,6 +154,15 @@ Signature: public class OrderService : IOrderService
 
 Use `--format json` when you need structured data for programmatic processing.
 
+### Source Retrieval
+
+```bash
+# After you narrow to one symbol, pull in a small implementation snippet
+codegraph query PlaceOrder --include-source --source-max-lines 12
+```
+
+Use `--include-source` only after you have the right symbol and want a token-safe inline body preview. If you only know the file path, use the MCP `codegraph_file` tool first to discover the symbols in that file, then come back to `codegraph query` for a snippet.
+
 ## Fallback Behavior
 
 If the query returns no results or the graph is unavailable:
@@ -170,4 +181,5 @@ If the query returns no results or the graph is unavailable:
 4. **Keep max-nodes ≤ 50** — large results overwhelm context windows
 5. **Prefer `context` format** — it's designed for LLM consumption with structured markdown
 6. **Use `json` for chaining** — when you need to process results programmatically
-7. **Query interfaces** — use `--kind resolves-to` or `--kind implements` to discover implementations
+7. **Use source snippets sparingly** — start with `--source-max-lines 8-20` and only inline source after the symbol is narrowed down
+8. **Query interfaces** — use `--kind resolves-to` or `--kind implements` to discover implementations

--- a/skills/codegraph-review/SKILL.md
+++ b/skills/codegraph-review/SKILL.md
@@ -137,6 +137,14 @@ Use `--format json` when you need to process multiple queries programmatically:
 codegraph query OrderService --depth 1 --format json
 ```
 
+When you need to inspect a changed implementation, first identify the affected symbol, then pull in a small snippet with:
+
+```bash
+codegraph query PlaceOrder --include-source --source-max-lines 12
+```
+
+If the review starts from a changed file path instead of a symbol, use the MCP `codegraph_file` tool to list the symbols in that file before querying one of them.
+
 ## Fallback Behavior
 
 1. **Graph is stale** → Re-index: `codegraph index --solution <path.sln|path.slnx> --changed-only`

--- a/src/CodeGraph.Indexer/Init/AgentTemplates.cs
+++ b/src/CodeGraph.Indexer/Init/AgentTemplates.cs
@@ -20,14 +20,15 @@ internal static class AgentTemplates
         2. **Scope** — `codegraph list assemblies` to find relevant projects
         3. **Query** — `codegraph query <symbol> --depth 1 --format compact` for relationships
         4. **Deepen** — increase `--depth` or add `--kind` filters to follow specific edges
-        5. **Detail** — only grep/view specific source lines when you need method bodies
+        5. **Detail** — use `codegraph query <symbol> --include-source --source-max-lines 12` for a small inline snippet after narrowing to one symbol; use `codegraph_file` / grep-view only when you need file-level context
 
         CLI defaults are optimized for token efficiency:
         - Format defaults to `compact` when output is piped (~3-5× fewer tokens than `context`)
         - Mode defaults to `focused` (high-signal edges only)
         - Use `--format context` when you need full signatures and metadata
         - Use `--mode all` only for exhaustive analysis
-        - Use `--include-source` only AFTER narrowing to a specific method — snippets are capped at 20 lines
+        - Use `--include-source` only AFTER narrowing to a specific method or type
+        - Keep `--source-max-lines` low (default: 20) to stay token-safe
         - Use `--json` on any command for machine-readable output
 
         This strategy uses ~4× fewer tokens than reading source files directly.
@@ -107,10 +108,11 @@ internal static class AgentTemplates
         2. **Scope** — `codegraph list assemblies` to find relevant projects
         3. **Query** — `codegraph query <symbol> --depth 1 --format compact`
         4. **Deepen** — increase `--depth` or add `--kind` to follow edges
-        5. **Detail** — only grep/view source when you need method bodies
+        5. **Detail** — use `codegraph query <symbol> --include-source --source-max-lines 12` for a small inline snippet after narrowing to one symbol; use `codegraph_file` or grep/view when you need file-level context
 
         CLI defaults are token-optimized: `compact` format + `focused` mode when piped.
         Use `--json` for machine-readable output. Use `--format context` for full detail.
+        Keep `--source-max-lines` low (default: 20) when you inline source.
 
         > **Use CLI commands** — they have zero schema overhead. MCP is available
         > as an alternative for IDE-only agents that cannot run shell commands.
@@ -164,7 +166,7 @@ internal static class AgentTemplates
         2. `codegraph list assemblies` to scope relevant projects
         3. `codegraph query <symbol> --depth 1 --format compact` for relationships
         4. Increase `--depth` or add `--kind calls|resolves-to|implements` to follow edges
-        5. Only grep/view source files when you need method bodies
+        5. Use `codegraph query <symbol> --include-source --source-max-lines 12` for a small inline snippet after narrowing to one symbol; use `codegraph_file` or grep/view when you need file-level context
 
         ### Commands
 

--- a/tests/CodeGraph.Indexer.Tests/Init/AgentTemplatesTests.cs
+++ b/tests/CodeGraph.Indexer.Tests/Init/AgentTemplatesTests.cs
@@ -10,6 +10,8 @@ public class AgentTemplatesTests
         Assert.Contains("codegraph query", AgentTemplates.ClaudeSkillMd);
         Assert.Contains("--depth", AgentTemplates.ClaudeSkillMd);
         Assert.Contains("--kind", AgentTemplates.ClaudeSkillMd);
+        Assert.Contains("--include-source", AgentTemplates.ClaudeSkillMd);
+        Assert.Contains("codegraph_file", AgentTemplates.ClaudeSkillMd);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- document when to use --include-source versus codegraph_file
- document --source-max-lines and token-safe snippet guidance in README, MCP docs, and skills
- update generated agent guidance and tests for the new source snippet workflow

Closes #105